### PR TITLE
Remove obsolete `popupTitle` translation string

### DIFF
--- a/language/ar.json
+++ b/language/ar.json
@@ -5,7 +5,6 @@
     "notVideoField":"\":path\" ليس فيديو.",
     "notImageField":"\":path\" ليست صورة.",
     "insertElement":"أنقر وحرك :type",
-    "popupTitle":"تحرير :type",
     "done":"تم الاطلاع عليه",
     "loading":"تحميل ...",
     "remove":"حذف",

--- a/language/bg.json
+++ b/language/bg.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" не е видео.",
     "notImageField": "\":path\" не е изображение.",
     "insertElement": "Кликнете и плъзнете, за да поставите :тип",
-    "popupTitle": "Редактиране на :типа",
     "done": "Готово",
     "loading": "Зареждане...",
     "remove": "Премахване",

--- a/language/bs.json
+++ b/language/bs.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" nije video.",
     "notImageField": "\":path\" nije slika.",
     "insertElement": "Klikni i donesi na donesi na odgovarajuće mjesto :type",
-    "popupTitle": "Uredi :type",
     "done": "Gotovo",
     "loading": "Učitava se...",
     "remove": "Ukloni",

--- a/language/ca.json
+++ b/language/ca.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" no es un vídeo.",
     "notImageField": "\":path\" no es una imatge.",
     "insertElement": "Feu clic i arrossegueu per col·locar :type",
-    "popupTitle": "Edita :type",
     "done": "Fet",
     "loading": "S’està carregant...",
     "remove": "Suprimeix",

--- a/language/cs.json
+++ b/language/cs.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" není video.",
     "notImageField": "\":path\" není obrázek.",
     "insertElement": "Klepnutím a tažením umístěte :type",
-    "popupTitle": "Upravit :type",
     "done": "Hotovo",
     "loading": "Nahrávání...",
     "remove": "Odstranit",

--- a/language/da.json
+++ b/language/da.json
@@ -5,7 +5,6 @@
     "notVideoField":"\":path\" er ikke en video.",
     "notImageField":"\":path\" er ikke et billede",
     "insertElement":"Klik og træk for at placere :type",
-    "popupTitle":"Ændre :type",
     "done":"Færdig",
     "loading":"Indlæser.",
     "remove":"Fjern",

--- a/language/de.json
+++ b/language/de.json
@@ -5,7 +5,6 @@
     "notVideoField": "Unter \":path\" ist kein Video zu finden.",
     "notImageField": "Unter \":path\" ist kein Bild zu finden.",
     "insertElement": "Klicken und an die gewünschte Stelle ziehen, um :type zu platzieren",
-    "popupTitle": ":type bearbeiten",
     "done": "Fertig",
     "loading": "Lädt...",
     "remove": "Entfernen",

--- a/language/el.json
+++ b/language/el.json
@@ -5,7 +5,6 @@
     "notVideoField":"Το \":path\" δεν είναι βίντεο",
     "notImageField":"Το \":path\" δεν είναι εικόνα",
     "insertElement":"Κάντε κλικ και τοποθετήστε το :type",
-    "popupTitle":"Επεξεργασία του :type",
     "done":"Ολοκλήρωση",
     "loading":"Φόρτωση...",
     "remove":"Αφαίρεση",

--- a/language/en.json
+++ b/language/en.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" is not a video.",
     "notImageField": "\":path\" is not a image.",
     "insertElement": "Click and drag to place :type",
-    "popupTitle": "Edit :type",
     "done": "Done",
     "loading": "Loading...",
     "remove": "Delete",

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" no es un video.",
     "notImageField": "\":path\" no es una imagen.",
     "insertElement": "Clic y arrastrar para colocar :type",
-    "popupTitle": "Editar :type",
     "done": "Hecho",
     "loading": "Cargando...",
     "remove": "Eliminar",

--- a/language/es.json
+++ b/language/es.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" no es un video.",
     "notImageField": "\":path\" no es una imagen.",
     "insertElement": "Clic y arrastrar para colocar :type",
-    "popupTitle": "Editar :type",
     "done": "Hecho",
     "loading": "Cargando...",
     "remove": "Eliminar",

--- a/language/et.json
+++ b/language/et.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" ei ole video.",
     "notImageField": "\":path\" ei ole pilt.",
     "insertElement": "Kliki ja lohista paika :type",
-    "popupTitle": "Töötle :type",
     "done": "Valmis",
     "loading": "Laadib...",
     "remove": "Eemalda",

--- a/language/eu.json
+++ b/language/eu.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" ez da bideo bat.",
     "notImageField": "\":path\" ez da irudi bat.",
     "insertElement": "Klikatu eta arrastatu hona: :type",
-    "popupTitle": "Editatu :type",
     "done": "Eginda",
     "loading": "Kargatzen...",
     "remove": "Ezabatu",

--- a/language/fa.json
+++ b/language/fa.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" یک ویدئو نیست.",
     "notImageField": "\":path\" یک تصویر نیست.",
     "insertElement": "برای قرار دادن :type کلیک کنید و بکشید",
-    "popupTitle": "ویرایش :type",
     "done": "انجام شد",
     "loading": "در حال بارگیری...",
     "remove": "حذف",

--- a/language/fi.json
+++ b/language/fi.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" ei ole video.",
     "notImageField": "\":path\" ei ole kuva.",
     "insertElement": "Klikkaa ja raahaa paikalleen :type",
-    "popupTitle": "Editoi :type",
     "done": "Valmis",
     "loading": "Lataa...",
     "remove": "Poista",

--- a/language/fr.json
+++ b/language/fr.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" n'est pas une vidéo.",
     "notImageField": "\":path\" n'est pas une image.",
     "insertElement": "Cliquez et glissez jusqu'à l'emplacement :type",
-    "popupTitle": "Édition :type",
     "done": "Valider",
     "loading": "Chargement...",
     "remove": "Supprimer",

--- a/language/he.json
+++ b/language/he.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" אינו וידאו.",
     "notImageField": "\":path\" זו לא תמונה.",
     "insertElement": "יש להקליק ולגרור למקום :type",
-    "popupTitle": "עריכת :type",
     "done": "הסתיים",
     "loading": "טוען...",
     "remove": "הסרה",

--- a/language/hr.json
+++ b/language/hr.json
@@ -5,7 +5,6 @@
   "notVideoField": "\":path\"  nije video.",
   "notImageField": "\":path\" nije slika.",
   "insertElement": "Kliknite i povucite na mjesto :type",
-  "popupTitle": "Uredi :type",
   "done": "Gotovo",
   "loading": "Učitavanje...",
   "remove": "Ukloni",

--- a/language/it.json
+++ b/language/it.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" non è un video",
     "notImageField": "\":path\" non è un'immagine",
     "insertElement": "Clicca e trascina per posizionare :type",
-    "popupTitle": "Modifica :type",
     "done": "Fatto",
     "loading": "Caricamento in corso...",
     "remove": "Elimina",

--- a/language/ko.json
+++ b/language/ko.json
@@ -6,7 +6,6 @@
     "notVideoField": "\":path\" 는 비디오가 아님.",
     "notImageField": "\":path\" 는 이미지가 아님.",
     "insertElement": "클릭해서 :type 로 끌어 놓기",
-    "popupTitle": "편집 :type",
     "done": "완료",
     "loading": "로딩중...",
     "remove": "삭제",

--- a/language/nb.json
+++ b/language/nb.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" er ikke en video.",
     "notImageField": "\":path\" er ikke et bilde.",
     "insertElement": "Klikk å dra for å plassere :type",
-    "popupTitle": "Endre :type",
     "done": "Ferdig",
     "loading": "Laster...",
     "remove": "Fjern",

--- a/language/nl.json
+++ b/language/nl.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" is geen video.",
     "notImageField": "\":path\" is geen afbeelding.",
     "insertElement": "Klik-en-sleep naar positie :type",
-    "popupTitle": "Bewerk :type",
     "done": "Klaar",
     "loading": "Aan het laden...",
     "remove": "Verwijder",

--- a/language/nn.json
+++ b/language/nn.json
@@ -5,7 +5,6 @@
     "notVideoField":"\":path\" er ikkje ein video.",
     "notImageField":"\":path\" er ikkje eit bilete.",
     "insertElement":"Klikk å dra for å plassere :type",
-    "popupTitle":"Endre :type",
     "done":"Ferdig",
     "loading":"Lastar.",
     "remove":"Fjern",

--- a/language/pl.json
+++ b/language/pl.json
@@ -5,7 +5,6 @@
     "notVideoField": "':path' nie jest filmem.",
     "notImageField": "':path' nie jest obrazem.",
     "insertElement": "Kliknij i przeciągnij, aby utworzyć :type",
-    "popupTitle": "Edytuj :type",
     "done": "Gotowe",
     "loading": "Ładuję...",
     "remove": "Usuń",

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" não é um vídeo.",
     "notImageField": "\":path\" não é uma imagem.",
     "insertElement": "Clique a arraste para posicionar :type",
-    "popupTitle": "Editar :type",
     "done": "Terminado",
     "loading": "Carregando...",
     "remove": "Remover",

--- a/language/ru.json
+++ b/language/ru.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" не является видео.",
     "notImageField": "\":path\" не является изображением.",
     "insertElement": "Нажмите и переместите на место :type",
-    "popupTitle": "Изменить :type",
     "done": "Готово",
     "loading": "Загрузка...",
     "remove": "Удалить",

--- a/language/sl.json
+++ b/language/sl.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" ni videoposnetek.",
     "notImageField": "\":path\" ni slika.",
     "insertElement": "S klikom postavi aktivnost :type",
-    "popupTitle": "Uredi :type",
     "done": "Potrdi",
     "loading": "Nalagam ...",
     "remove": "Izbriši",

--- a/language/sma.json
+++ b/language/sma.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" is not a video.",
     "notImageField": "\":path\" is not a image.",
     "insertElement": "Click and drag to place :type",
-    "popupTitle": "Edit :type",
     "done": "Done",
     "loading": "Loading...",
     "remove": "Delete",

--- a/language/sme.json
+++ b/language/sme.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" is not a video.",
     "notImageField": "\":path\" is not a image.",
     "insertElement": "Click and drag to place :type",
-    "popupTitle": "Edit :type",
     "done": "Done",
     "loading": "Loading...",
     "remove": "Delete",

--- a/language/smj.json
+++ b/language/smj.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" is not a video.",
     "notImageField": "\":path\" is not a image.",
     "insertElement": "Click and drag to place :type",
-    "popupTitle": "Edit :type",
     "done": "Done",
     "loading": "Loading...",
     "remove": "Delete",

--- a/language/sv.json
+++ b/language/sv.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" är inte en video.",
     "notImageField": "\":path\" är inte en bild.",
     "insertElement": "Klicka och dra för att placera ut :type",
-    "popupTitle": "Redigera :type",
     "done": "Färdig",
     "loading": "Laddar...",
     "remove": "Radera",

--- a/language/tr.json
+++ b/language/tr.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" bir video değil.",
     "notImageField": "\":path\" bir resim değil.",
     "insertElement": ":type alanına yerleştirmek için tıklayın ve sürükleyin ",
-    "popupTitle": ":type düzenleyin",
     "done": "Tamamlandı",
     "loading": "Yükleniyor...",
     "remove": "Sil",

--- a/language/zh.json
+++ b/language/zh.json
@@ -5,7 +5,6 @@
     "notVideoField": "\":path\" - 無法識別的影片。",
     "notImageField": "\":path\" - 無法識別的圖片。",
     "insertElement": "点击并拖拽以添加 :type",
-    "popupTitle": "變更 :type",
     "done": "完成",
     "loading": "正在加载...",
     "remove": "移除",


### PR DESCRIPTION
The `popupTitle` string is not used anywhere in the Interactive Video editor. When merged in, the string will be removed from all the translation files.