### PR TITLE
Fix styling the non-form parts of the H5P Hub

### DIFF
--- a/styles/interactive-video-editor.css
+++ b/styles/interactive-video-editor.css
@@ -387,17 +387,17 @@
   margin: 0;
   padding: 0;
 }
-.h5p-interactivevideo-editor textarea, .h5p-interactivevideo-editor input[type="text"]:not(.h5p-dragnbar-x):not(.h5p-dragnbar-y), .h5p-interactivevideo-editor .ckeditor {
+.h5p-interactivevideo-editor .h5peditor-form textarea, .h5p-interactivevideo-editor .h5peditor-form input[type="text"]:not(.h5p-dragnbar-x):not(.h5p-dragnbar-y), .h5p-interactivevideo-editor .ckeditor {
   border: 1px solid #dbdbdb;
   border-radius: 0;
   background: #fff;
 }
-.h5p-interactivevideo-editor textarea:focus, .h5p-interactivevideo-editor input[type="text"]:not(.h5p-dragnbar-x):not(.h5p-dragnbar-y):focus {
+.h5p-interactivevideo-editor .h5peditor-form textarea:focus, .h5p-interactivevideo-editor .h5peditor-form input[type="text"]:not(.h5p-dragnbar-x):not(.h5p-dragnbar-y):focus {
   background: #fff;
   border-color: #dbdbdb;
   box-shadow: 0 0 0.25em #dbdbdb inset;
 }
-.h5p-interactivevideo-editor table.h5p-table, .h5p-interactivevideo-editor .h5p-table td, .h5p-interactivevideo-editor .h5p-table th {
+.h5p-interactivevideo-editor .h5peditor-form table.h5p-table, .h5p-interactivevideo-editor .h5peditor-form .h5p-table td, .h5p-interactivevideo-editor .h5peditor-form .h5p-table th {
   border: 1px dashed #999;
 }
 


### PR DESCRIPTION
When merged in, will limit some of the style changes to the `h5p-form` class, because the general nature of the the selector influenced other parts of the H5P Hub, in particular overwriting the `border-radius` of the `h5p-hub-search-bar` class leading to a square content search bar.